### PR TITLE
Auto assume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM openjdk:8u171-jre-alpine3.8
 
-ENV OKTA_VERSION=1.0.6
+ENV OKTA_VERSION=1.0.8
 ENV OKTA_RELEASE=https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/v${OKTA_VERSION}/okta-aws-cli-${OKTA_VERSION}.jar
 
 # install aws cli
-RUN apk add --update --no-cache python py-pip git curl make
+RUN apk add --update --no-cache python py-pip git curl make bash
 RUN pip install awscli --upgrade
 
 # move okta jar into bin
 RUN curl -sSL ${OKTA_RELEASE} > /usr/bin/okta-aws-cli.jar
 
-# create a wrapper to call all aws commands via okta and make executable
-RUN echo -e '#!/bin/sh\njava -classpath /usr/bin/okta-aws-cli.jar com.okta.tools.awscli $@' > /usr/bin/awscli
-RUN chmod a+x /usr/bin/awscli
+# create a auto assume wrapper
+COPY awscli /usr/bin/awscli
+
+# set as default command
+CMD ["awscli"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OKTA_VERISON = 1.0.6
+OKTA_VERISON = 1.0.8
 IMAGE_NAME ?= contino/okta-aws:$(OKTA_VERISON)
 TAG = $(OKTA_VERISON)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Here are some quick environment variables to get you started:
 - `OKTA_AWS_APP_URL` - Your unique application URL. Must be set.
 - `OKTA_AWS_ROLE_TO_ASSUME` - The initial role to assume if found, otherwise will prompt  with list (default: '')
 - `OKTA_AWS_DEFAULT_REGION` - The region your Okta login is to take place in (default: 'ap-southeast-2')
+- `OKTA_USERNAME` - Your personal Okta username, if not set will be prompted to enter in manually
 
 If requiring an assume role after your primary Okta login, these variables
 can be used to automatically assume into the role desired:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Here are some quick environment variables to get you started:
 - `OKTA_AWS_ROLE_TO_ASSUME` - The initial role to assume if found, otherwise will prompt  with list (default: '')
 - `OKTA_AWS_DEFAULT_REGION` - The region your Okta login is to take place in (default: 'ap-southeast-2')
 - `OKTA_USERNAME` - Your personal Okta username, if not set will be prompted to enter in manually
+- `OKTA_AWS_PROFILE` - Custom name for the okta profile to use (default: 'default')
 
 If requiring an assume role after your primary Okta login, these variables
 can be used to automatically assume into the role desired:

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 Containerised Okta CLI with Python AWS sdks installed.
 
 ## Usage
+The below 2 examples assume that you will be utilising environment
+variables within a .env file. A configuration file can be bind mounted instead.
+
+### Docker
 Run as a command:
 
 ```
 docker run --rm -v ~/.aws:/root/.aws contino/okta-aws
 ```
 
+### Docker-Compose
 Using docker-compose:
 
 ```
@@ -20,19 +25,24 @@ okta:
 
 And run `docker-compose run okta` to be prompted with username and password.
 
+### Bash
 Can also set as a bash function and placed in your `~/.bashrc` or equivalent
-for quick access:
+for quick access, with a configuration file:
 
 ```
-function okta { docker run --rm -it -v ~/.aws:/root/.aws contino/okta-aws; }
+function okta() {
+  docker run --rm -it -v ~/.okta/config.properties:/root/.okta/config.properties -v ~/.aws:/root/.aws contino/okta-aws;
+}
 ```
 
 Then run `okta` on your terminal to be prompted.
 
-## Extra Configuration
+## Configuration
 Please see [okta](https://github.com/oktadeveloper/okta-aws-cli-assume-role)
-for further detail on Okta related configuration. Here are some quick
-environment variables to get you started:
+for further detail on Okta related configuration.
+
+### Environment Variables
+Here are some quick environment variables to get you started:
 
 - `OKTA_ORG` - Name of your organisation in Okta settings. Must be set.
 - `OKTA_AWS_APP_URL` - Your unique application URL. Must be set.
@@ -44,6 +54,18 @@ can be used to automatically assume into the role desired:
 
 - `AWS_ASSUME_ROLE_ARN` - The full ARN of the account and role you wish to assume into after Okta authentication
 - `AWS_ASSUME_SESSION_NAME` - Custom session name to be used in assuming (default: 'OktaAssumeRole')
+
+### Configuration File
+If wanting to store all configuration for Okta in a static file instead, you
+have the functionality to bind mount a configuration file directly into the
+container. See below example of what it can look like.
+
+Save below contents in a file located `~/.okta/config.properties`:
+
+```
+OKTA_ORG=my-org.okta.com
+OKTA_AWS_APP_URL=https://my-org.okta.com/home/amazon_aws/123456789
+```
 
 ## Build
 Update the `OKTA_VERSION` in both `Makefile` and `DockerFile`. The run:

--- a/README.md
+++ b/README.md
@@ -5,18 +5,17 @@ Containerised Okta CLI with Python AWS sdks installed.
 Run as a command:
 
 ```
-docker run --rm -v ~/.aws:/root/.aws contino/okta
+docker run --rm -v ~/.aws:/root/.aws contino/okta-aws
 ```
 
 Using docker-compose:
 
 ```
-terraform:
-image: contino/okta
-env_file: .env
-working_dir: /opt/app
-volumes:
-  - ~/.aws:/root/.aws
+okta:
+  image: contino/okta-aws
+  env_file: .env
+  volumes:
+    - ~/.aws:/root/.aws
 ```
 
 And run `docker-compose run okta` to be prompted with username and password.
@@ -25,7 +24,7 @@ Can also set as a bash function and placed in your `~/.bashrc` or equivalent
 for quick access:
 
 ```
-function okta { docker run --rm -it -v ~/.aws:/root/.aws contino/okta; }
+function okta { docker run --rm -it -v ~/.aws:/root/.aws contino/okta-aws; }
 ```
 
 Then run `okta` on your terminal to be prompted.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
 # Docker Okta
+Containerised Okta CLI with Python AWS sdks installed.
+
+## Usage
+Run as a command:
+
+```
+docker run --rm -v ~/.aws:/root/.aws contino/okta
+```
+
+Using docker-compose:
+
+```
+terraform:
+image: contino/okta
+env_file: .env
+working_dir: /opt/app
+volumes:
+  - ~/.aws:/root/.aws
+```
+
+And run `docker-compose run okta` to be prompted with username and password.
+
+Can also set as a bash function and placed in your `~/.bashrc` or equivalent
+for quick access:
+
+```
+function okta { docker run --rm -it -v ~/.aws:/root/.aws contino/okta; }
+```
+
+Then run `okta` on your terminal to be prompted.
+
+## Extra Configuration
+Please see [okta](https://github.com/oktadeveloper/okta-aws-cli-assume-role)
+for further detail on Okta related configuration. Here are some quick
+environment variables to get you started:
+
+- `OKTA_ORG` - Name of your organisation in Okta settings. Must be set.
+- `OKTA_AWS_APP_URL` - Your unique application URL. Must be set.
+- `OKTA_AWS_ROLE_TO_ASSUME` - The initial role to assume if found, otherwise will prompt  with list (default: '')
+- `OKTA_AWS_DEFAULT_REGION` - The region your Okta login is to take place in (default: 'ap-southeast-2')
+
+If requiring an assume role after your primary Okta login, these variables
+can be used to automatically assume into the role desired:
+
+- `AWS_ASSUME_ROLE_ARN` - The full ARN of the account and role you wish to assume into after Okta authentication
+- `AWS_ASSUME_SESSION_NAME` - Custom session name to be used in assuming (default: 'OktaAssumeRole')
+
+## Build
+Update the `OKTA_VERSION` in both `Makefile` and `DockerFile`. The run:
+
+    make build
+
+Docker Hub will automatically triger a new build.
+
+## Related Projects
+- [hashicorp/terraform](https://hub.docker.com/r/hashicorp/terraform/)
+- [docker-aws-cli](https://github.com/contino/docker-aws-cli)

--- a/awscli
+++ b/awscli
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 # Initialise AWS CLI
 aws configure set region "${OKTA_AWS_DEFAULT_REGION:-ap-southeast-2}"

--- a/awscli
+++ b/awscli
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# Initialise AWS CLI
+aws configure set region "${OKTA_AWS_DEFAULT_REGION:-ap-southeast-2}"
+
+# Primary OKTA login
+java -classpath /usr/bin/okta-aws-cli.jar com.okta.tools.awscli \
+     --profile default sts get-caller-identity
+
+# Assume role if specified
+if [[ -n "${AWS_ASSUME_ROLE_ARN}" ]]; then
+
+  # Assume into specified role
+  assumed_role_details=$(aws sts assume-role \
+    --role-arn "${AWS_ASSUME_ROLE_ARN}" \
+    --role-session-name "${AWS_ASSUME_SESSION_NAME:-OktaAssumeRole}" \
+    --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
+    --output text)
+
+  # Split results
+  aws_access_key_id=$(echo "${assumed_role_details}" | cut -f1)
+  aws_secret_access_key=$(echo "${assumed_role_details}" | cut -f2)
+  aws_session_token=$(echo "${assumed_role_details}" | cut -f3)
+
+  # Set aws credentials
+  aws configure set aws_access_key_id "${aws_access_key_id}"
+  aws configure set aws_secret_access_key "${aws_secret_access_key}"
+  aws configure set aws_session_token "${aws_session_token}"
+
+  # Secondary AWS login
+  assumed_role=$(aws sts get-caller-identity --query "Arn" --output text)
+  echo -e "\nAssumed secondary AWS role as: ${assumed_role}"
+fi

--- a/awscli
+++ b/awscli
@@ -1,15 +1,17 @@
 #!/bin/bash
-set -eo pipefail
+set -euo pipefail
 
 # Initialise AWS CLI
 aws configure set region "${OKTA_AWS_DEFAULT_REGION:-ap-southeast-2}"
 
 # Primary OKTA login
-java -classpath /usr/bin/okta-aws-cli.jar com.okta.tools.awscli \
-     --profile default sts get-caller-identity
+java "-Duser.home=${HOME}" \
+     -classpath /usr/bin/okta-aws-cli.jar com.okta.tools.awscli \
+     --profile "${OKTA_AWS_PROFILE:-default}" sts get-caller-identity
 
 # Assume role if specified
-if [[ -n "${AWS_ASSUME_ROLE_ARN}" ]]; then
+AWS_ASSUME_ROLE_ARN="${AWS_ASSUME_ROLE_ARN:-}"
+if [[ ! -z "${AWS_ASSUME_ROLE_ARN}" ]]; then
   echo -e "\nAssuming role as: ${AWS_ASSUME_ROLE_ARN}"
   assumed_role_details=$(aws sts assume-role \
     --role-arn "${AWS_ASSUME_ROLE_ARN}" \
@@ -27,6 +29,6 @@ if [[ -n "${AWS_ASSUME_ROLE_ARN}" ]]; then
   aws configure set aws_secret_access_key "${aws_secret_access_key}"
   aws configure set aws_session_token "${aws_session_token}"
 
-  # Secondary AWS login
+  # Print out secondary role information
   aws sts get-caller-identity
 fi

--- a/awscli
+++ b/awscli
@@ -10,8 +10,7 @@ java -classpath /usr/bin/okta-aws-cli.jar com.okta.tools.awscli \
 
 # Assume role if specified
 if [[ -n "${AWS_ASSUME_ROLE_ARN}" ]]; then
-
-  # Assume into specified role
+  echo -e "\nAssuming role as: ${AWS_ASSUME_ROLE_ARN}"
   assumed_role_details=$(aws sts assume-role \
     --role-arn "${AWS_ASSUME_ROLE_ARN}" \
     --role-session-name "${AWS_ASSUME_SESSION_NAME:-OktaAssumeRole}" \
@@ -29,6 +28,5 @@ if [[ -n "${AWS_ASSUME_ROLE_ARN}" ]]; then
   aws configure set aws_session_token "${aws_session_token}"
 
   # Secondary AWS login
-  assumed_role=$(aws sts get-caller-identity --query "Arn" --output text)
-  echo -e "\nAssumed secondary AWS role as: ${assumed_role}"
+  aws sts get-caller-identity
 fi


### PR DESCRIPTION
## Version
- Bump to latest version of 1.0.8

## Enable functionality for secondary assume
- Added awscli wrapper to repository, this will enable optional secondary assume into AWS account (thanks to @chamila-c for inspiring this)
- Remove the need for any custom logic outside of this container to assume, can be done all in one

## README update
- Create instructions on how to use this container and image correctly