### PR TITLE
Install python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ ENV OKTA_VERSION=1.0.10
 ENV OKTA_RELEASE=https://github.com/oktadeveloper/okta-aws-cli-assume-role/releases/download/v${OKTA_VERSION}/okta-aws-cli-${OKTA_VERSION}.jar
 
 # install aws cli
-RUN apk add --update --no-cache python py-pip git curl make bash
-RUN pip install awscli --upgrade
+RUN apk add --update --no-cache python3 git curl make bash
+RUN pip3 install --upgrade pip
+RUN pip3 install awscli
 
 # move okta jar into bin
 RUN curl -sSL ${OKTA_RELEASE} > /usr/bin/okta-aws-cli.jar

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .SILENT:
 OKTA_VERISON = 1.0.10
-IMAGE_NAME ?= contino/okta-aws:$(OKTA_VERISON)
-TAG = $(OKTA_VERISON)
+TAG = $(OKTA_VERISON)-1
+IMAGE_NAME ?= contino/okta-aws:$(TAG)
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .SILENT:
-OKTA_VERISON = 1.0.10
-TAG = $(OKTA_VERISON)-1
+OKTA_VERSION = 1.0.10
+TAG = $(OKTA_VERSION)-1
 IMAGE_NAME ?= contino/okta-aws:$(TAG)
 
 .PHONY: build


### PR DESCRIPTION
Upgrade to Python3.
This will be a 'breaking' change for any consumer that is using Python within this image.

If this is too dangerous, possible solutions:
- Install Python2 & Python3. Use Python3 (`pip3`) to install `awscli`. This will still introduce problems for consumers that expect packages in Python2 that were installed as dependencies of the `awscli` package (for example, the `yaml` package).

- Update the tagging convention to support changes in the image where the version of `okta-aws-cli-assume-role` has not changed. e.g. Current Okta version is `1.0.10`, we could create the tag: `1.0.10-1` 